### PR TITLE
Remove `bottle :unneeded`

### DIFF
--- a/dagger.rb
+++ b/dagger.rb
@@ -6,7 +6,6 @@ class Dagger < Formula
   desc "Dagger is a programmable deployment system."
   homepage "https://github.com/dagger/dagger"
   version "0.1.0-alpha.27"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
I'm getting this error from homebrew: 
```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the dagger/tap tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Library/Taps/dagger/homebrew-tap/dagger.rb:9
```